### PR TITLE
security policy inline breaking when deployed

### DIFF
--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -1,19 +1,19 @@
 const siteMetadata = {
-  title: 'Very Local Nashville',
+  title: 'Very Local Weather Nashville',
   author: 'David Rhodes',
   headerTitle: 'Nashville Weather',
   description: 'Local weather in Nashville',
   language: 'en-us',
   theme: 'light', // system, dark or light
-  // siteUrl: 'https://verylocalweather.vercel.app/',
+  siteUrl: 'https://verylocalweather.vercel.app/',
   // image: '/static/images/avatar-one.png',
   // socialBanner: '/static/images/twitter-card-two.png',
-  // email: 'david@espressocode.tech',
-  // github: 'https://github.com/dfrho',
+  email: 'david@espressocode.tech',
+  github: 'https://github.com/dfrho',
   twitter: 'https://twitter.com/Twitter',
   facebook: 'https://facebook.com',
   youtube: 'https://youtube.com',
-  // linkedin: 'https://www.linkedin.com/in/rhodesdavid/',
+  linkedin: 'https://www.linkedin.com/in/rhodesdavid/',
   locale: 'en-US',
   analytics: {
     // If you want to use an analytics provider you have to add it to the

--- a/next.config.js
+++ b/next.config.js
@@ -3,16 +3,18 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 })
 
 // You might need to insert additional domains in script-src if you are using external services
-const ContentSecurityPolicy = `
-  default-src 'self';
-  script-src 'self' 'unsafe-inline';
-  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
-  img-src * blob: data:;
-  font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;
-  media-src 'none';
-  connect-src *;
-  frame-src https://www.youtube.com https://app.posthog.com
-`
+// const ContentSecurityPolicy = `
+//   default-src 'self';
+//   script-src 'self' 'unsafe-inline';
+//   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+//   img-src * blob: data:;
+//   font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;
+//   media-src 'none';
+//   connect-src *;
+//   frame-src https://www.youtube.com https://app.posthog.com
+// `
+const ContentSecurityPolicy =
+  "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src * blob: data:; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; media-src 'none'; connect-src *; frame-src https://www.youtube.com https://app.posthog.com;"
 
 const securityHeaders = [
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP


### PR DESCRIPTION
-Cleans up siteMetaData for items needed in Footer
-Puts ContentSecurity policy inline to avoid new lines that were breaking